### PR TITLE
early escape check dynamic result

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rbac-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": " Ocean role-based access control server",
   "main": "./dist/app.js",
   "scripts": {

--- a/src/authModules/authenticateProfile.ts
+++ b/src/authModules/authenticateProfile.ts
@@ -5,11 +5,12 @@ import { Credentials, Credential } from '@oceanprotocol/lib'
 async function checkCredentials(
   credentialArray: Credential[],
   profile: any,
-  credentials: requestCredentials
+  credentials: requestCredentials,
+  skippedCheckResult = true
 ): Promise<boolean> {
   try {
     if (credentialArray === undefined || credentialArray.length === 0) {
-      return true
+      return skippedCheckResult
     } else {
       for (let i = 0; i < credentialArray.length; i++) {
         const type = credentialArray[i].type
@@ -45,7 +46,8 @@ async function authenticateProfile(
     const isDenied = await checkCredentials(
       ddoCredentials.deny,
       profile,
-      credentials
+      credentials,
+      false
     )
 
     if (isAllowed === false || isDenied === true) {


### PR DESCRIPTION
To allow dynamic result when early escape because empty checking list from ddo

isDenied of authenticateProfile would be false when ddo.denyList is empty

Changes:

- Dynamic result when early escape because empty checking list from ddo
