### PR TITLE
rename oauth type, so wont clash for keycloak

### DIFF
--- a/src/controllers/roleController.ts
+++ b/src/controllers/roleController.ts
@@ -19,10 +19,10 @@ function roleController(
     case 'json':
       json(res, credentials.value, eventType, component)
       break
-    case 'keycloak':
+    case 'oauth':
       keycloak(res, credentials.value, eventType, component)
       break
-    case 'address':
+    case 'keycloak':
       address(res, credentials.value, eventType, component)
       break
     default:

--- a/src/data/users.ts
+++ b/src/data/users.ts
@@ -1,6 +1,6 @@
 const users = [
   {
-    authType: 'address',
+    authType: 'oauth',
     auth: '0x0123456789',
     role: 'admin'
   },
@@ -20,7 +20,7 @@ const users = [
     role: 'user'
   },
   {
-    authType: 'address',
+    authType: 'oauth',
     auth: '0x948943387239032',
     role: 'admin'
   }


### PR DESCRIPTION
Fixes # .

Changes proposed in this PR:

- rename keycloak to oauth
- reserve keycloak authService for extended consume checking along with keycloak
- 