### PR TITLE
Changing dependabot update interval from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: weekly
+      interval: monthly
       time: '03:00'
       timezone: Europe/Berlin


### PR DESCRIPTION
Changes proposed in this PR:

- No need for such regular updates on this repo, so changing from weekly to monthly.